### PR TITLE
Fix mnemonic in `Main.sublime-menu`

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -7,7 +7,7 @@
         [
             {
                 "caption": "CSV",
-                "mnemonic": "c",
+                "mnemonic": "C",
                 "id": "csv",
                 "children":
                 [


### PR DESCRIPTION
This removes `warning: mnemonic c not found in menu caption CSV` logs from Sublime Text log.